### PR TITLE
Solve undefined index issue with verse 6 of Surat Al Bakara

### DIFF
--- a/src/Arabic.php
+++ b/src/Arabic.php
@@ -2710,7 +2710,7 @@ class Arabic
 
             // handle the case of HARAKAT
             if (mb_strpos($this->arGlyphsVowel, $crntChar) !== false) {
-                if ($crntChar == 'ّ') {
+                if ($crntChar == 'ّ'.'ﱞ') {
                     if (mb_strpos($this->arGlyphsVowel, $chars[$i - 1]) !== false) {
                         // check if the SHADDA & HARAKA in the middle of connected letters (form 3)
                         if (


### PR DESCRIPTION
In some Quranic text an undefined index error is generated due to the absence of some vowels. I fetched for one of them and I found the *arabic ligature shadda with dammatan isolated form (U+FC5E)* is absent and I added it to `$crntChar string by concatenate it to the already string. This solution solve also another verses issues with that error such as Verse 18 of the same sura